### PR TITLE
Add function to remove projects from Codewind

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
@@ -51,6 +51,7 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
     private final AnAction refreshAction;
     private final AnAction openPerformanceDashboardAction;
     private final AnAction openTektonDashboardAction;
+    private final AnAction removeProjectAction;
 
     public CodewindToolWindow() {
         treeModel = new CodewindTreeModel();
@@ -66,6 +67,7 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
         refreshAction = new RefreshAction();
         openPerformanceDashboardAction = new OpenPerformanceDashboardAction();
         openTektonDashboardAction = new OpenTektonDashboardAction();
+        removeProjectAction = new RemoveProjectAction();
 
         debugAction = new AnAction("* debug *") {
             @Override
@@ -186,13 +188,6 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
     private void handleApplicationPopup(CodewindApplication application, Component component, int x, int y) {
         DefaultActionGroup actions = new DefaultActionGroup("CodewindApplicationGroup", true);
         actions.add(openApplicationAction);
-        actions.addSeparator();
-        actions.add(openIdeaProjectAction);
-        actions.addSeparator();
-        actions.add(startBuildAction);
-        actions.addSeparator();
-        actions.add(refreshAction);
-        actions.addSeparator();
         actions.add(openPerformanceDashboardAction);
         CodewindConnection connection = application.getConnection();
         if (connection != null) {
@@ -202,6 +197,14 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
                 actions.add(openTektonDashboardAction);
             }
         }
+        actions.addSeparator();
+        actions.add(openIdeaProjectAction);
+        actions.addSeparator();
+        actions.add(startBuildAction);
+        actions.addSeparator();
+        actions.add(refreshAction);
+        actions.addSeparator();
+        actions.add(removeProjectAction);
         ActionPopupMenu popupMenu = ActionManager.getInstance().createActionPopupMenu("CodewindTree", actions);
         popupMenu.getComponent().show(component, x, y);
     }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/RemoveProjectAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/RemoveProjectAction.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.intellij.ui.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.ui.treeStructure.Tree;
+import org.eclipse.codewind.intellij.core.CodewindApplication;
+import org.eclipse.codewind.intellij.core.Logger;
+import org.eclipse.codewind.intellij.ui.tasks.RemoveProjectTask;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.tree.TreePath;
+
+import static com.intellij.openapi.actionSystem.PlatformDataKeys.CONTEXT_COMPONENT;
+import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
+
+public class RemoveProjectAction extends AnAction {
+
+    public RemoveProjectAction() {
+        super(message("UnbindActionLabel"));
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Object data = e.getData(CONTEXT_COMPONENT);
+        if (!(data instanceof Tree)) {
+            Logger.log("unrecognized component for RemoveProjectAction: " + data);
+            System.out.println("*** unrecognized component for RemoveProjectAction: " + data);
+            return;
+        }
+
+        Tree tree = (Tree) data;
+        TreePath treePath = tree.getSelectionPath();
+        if (treePath == null) {
+            Logger.log("no selection for RemoveProjectAction: " + data);
+            System.out.println("*** no selection for RemoveProjectAction: " + data);
+            return;
+        }
+
+        Object node = treePath.getLastPathComponent();
+        if (!(node instanceof CodewindApplication)) {
+            Logger.log("selection for RemoveProjectAction is not a project: " + data);
+            System.out.println("*** selection for RemoveProjectAction is not a project: " + data);
+            return;
+        }
+
+        CodewindApplication application = (CodewindApplication) node;
+
+        String title = message("UnbindActionTitle");
+        String message = message("UnbindActionMessage", application.name);
+        int response = Messages.showConfirmationDialog(tree, message, title, Messages.OK_BUTTON, Messages.CANCEL_BUTTON);
+        if (response == Messages.OK) {
+            ProgressManager.getInstance().run(new RemoveProjectTask(application));
+        }
+    }
+}

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/RemoveProjectTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/RemoveProjectTask.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.intellij.ui.tasks;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.ui.Messages;
+import org.eclipse.codewind.intellij.core.CodewindApplication;
+import org.eclipse.codewind.intellij.core.Logger;
+import org.eclipse.codewind.intellij.core.cli.ProjectUtil;
+import org.jetbrains.annotations.NotNull;
+
+import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
+
+public class RemoveProjectTask extends Task.Backgroundable {
+    private final CodewindApplication application;
+
+    public RemoveProjectTask(CodewindApplication application) {
+        super(null, message("UnbindActionJobTitle"));
+        this.application = application;
+    }
+
+    @Override
+    public void run(@NotNull ProgressIndicator indicator) {
+        try {
+            ProjectUtil.removeProject(application.name, application.projectID, indicator);
+        } catch (Exception e) {
+            // Rethrown exception will be handled in #onThrowable()
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void onThrowable(@NotNull Throwable error) {
+        Throwable t = error;
+        while (t.getCause() != null)
+            t = t.getCause();
+        Logger.logWarning("An error occurred removing project " + application.name, t);
+        Messages.showErrorDialog(message("UnbindActionError", application.name, t.getLocalizedMessage()), message("CodewindLabel"));
+    }
+}

--- a/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
+++ b/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
@@ -113,7 +113,7 @@ UnbindActionLocationLabel=Project location:
 UnbindActionMultipleLocationLabel={0} project locations:
 UnbindActionJobTitle=Removing project: {0}
 UnbindActionMultipleJobTitle=Removing {0} projects
-UnbindActionError=An error occurred trying to remove the {0} project from Codewind.
+UnbindActionError=An error occurred trying to remove the {0} project from Codewind: {1}
 
 BindProjectErrorTitle=Add Existing Project Error
 BindProjectConnectionError=Adding the project failed because a connection to Codewind could not be established. Check workspace logs for details.


### PR DESCRIPTION
Initial drop which doesn't offer to delete the project from disk.
That will come later.

Also reorganized the context menu to match the order of items used by the Eclipse plugin.

Signed-off-by: John Pitman <jspitman@ca.ibm.com>