### PR TITLE
Add enable/disable autobuild menu item

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
@@ -48,6 +48,8 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
     private final AnAction openApplicationAction;
     private final AnAction openIdeaProjectAction;
     private final AnAction startBuildAction;
+    private final AnAction enableAutoBuildAction;
+    private final AnAction disableAutoBuildAction;
     private final AnAction refreshAction;
     private final AnAction openPerformanceDashboardAction;
     private final AnAction openTektonDashboardAction;
@@ -64,6 +66,8 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
         openApplicationAction = new OpenApplicationAction();
         openIdeaProjectAction = new OpenIdeaProjectAction();
         startBuildAction = new StartBuildAction();
+        enableAutoBuildAction = new EnableAutoBuildAction();
+        disableAutoBuildAction = new DisableAutoBuildAction();
         refreshAction = new RefreshAction();
         openPerformanceDashboardAction = new OpenPerformanceDashboardAction();
         openTektonDashboardAction = new OpenTektonDashboardAction();
@@ -187,6 +191,7 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
 
     private void handleApplicationPopup(CodewindApplication application, Component component, int x, int y) {
         DefaultActionGroup actions = new DefaultActionGroup("CodewindApplicationGroup", true);
+
         actions.add(openApplicationAction);
         actions.add(openPerformanceDashboardAction);
         CodewindConnection connection = application.getConnection();
@@ -197,14 +202,24 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
                 actions.add(openTektonDashboardAction);
             }
         }
+
         actions.addSeparator();
         actions.add(openIdeaProjectAction);
+
         actions.addSeparator();
         actions.add(startBuildAction);
-        actions.addSeparator();
-        actions.add(refreshAction);
+        if (application.isAutoBuild()) {
+            actions.add(disableAutoBuildAction);
+        } else {
+            actions.add(enableAutoBuildAction);
+        }
+
         actions.addSeparator();
         actions.add(removeProjectAction);
+
+        actions.addSeparator();
+        actions.add(refreshAction);
+
         ActionPopupMenu popupMenu = ActionManager.getInstance().createActionPopupMenu("CodewindTree", actions);
         popupMenu.getComponent().show(component, x, y);
     }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/DisableAutoBuildAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/DisableAutoBuildAction.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.intellij.ui.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.eclipse.codewind.intellij.core.CodewindApplication;
+import org.eclipse.codewind.intellij.ui.tasks.AutoBuildTask;
+import org.jetbrains.annotations.NotNull;
+
+import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
+
+public class DisableAutoBuildAction extends TreeAction<CodewindApplication> {
+
+    public DisableAutoBuildAction() {
+        super(message("DisableAutoBuildLabel"), CodewindApplication.class, AutoBuildTask::createDisabler);
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        // Set the menu item enablement based on whether the application is available
+        getSelection(e).ifPresent(application -> e.getPresentation().setEnabled(application.isAvailable()));
+    }
+}

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/EnableAutoBuildAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/EnableAutoBuildAction.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.intellij.ui.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.eclipse.codewind.intellij.core.CodewindApplication;
+import org.eclipse.codewind.intellij.ui.tasks.AutoBuildTask;
+import org.jetbrains.annotations.NotNull;
+
+import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
+
+public class EnableAutoBuildAction extends TreeAction<CodewindApplication> {
+
+    public EnableAutoBuildAction() {
+        super(message("EnableAutoBuildLabel"), CodewindApplication.class, AutoBuildTask::createEnabler);
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        // Set the menu item enablement based on whether the application is available
+        getSelection(e).ifPresent(application -> e.getPresentation().setEnabled(application.isAvailable()));
+    }
+
+}

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/OpenPerformanceDashboardAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/OpenPerformanceDashboardAction.java
@@ -17,14 +17,11 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.ui.treeStructure.Tree;
 import org.eclipse.codewind.intellij.core.CodewindApplication;
 import org.eclipse.codewind.intellij.core.Logger;
-import org.eclipse.codewind.intellij.core.connection.CodewindConnection;
-import org.eclipse.codewind.intellij.core.connection.ConnectionManager;
 import org.eclipse.codewind.intellij.ui.tasks.RefreshTask;
 import org.eclipse.codewind.intellij.ui.tree.CodewindTreeModel;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.tree.TreePath;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -35,7 +32,7 @@ import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message
 public class OpenPerformanceDashboardAction extends AnAction {
 
     public OpenPerformanceDashboardAction() {
-        super("Open Performance Dashboard");
+        super(message("ActionOpenPerformanceMonitor"));
     }
 
     @Override

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/TreeAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/TreeAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -42,7 +42,7 @@ public abstract class TreeAction<T> extends AnAction {
         getSelection(e).ifPresent(value -> ProgressManager.getInstance().run(taskFactory.apply(value)));
     }
 
-    private Optional<T> getSelection(@NotNull AnActionEvent e) {
+    protected Optional<T> getSelection(@NotNull AnActionEvent e) {
         Object data = e.getData(CONTEXT_COMPONENT);
         if (!(data instanceof Tree)) {
             Logger.logWarning("unrecognized component for action " + text + ": " + data);

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/AutoBuildTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/AutoBuildTask.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.intellij.ui.tasks;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.ui.Messages;
+import org.eclipse.codewind.intellij.core.CodewindApplication;
+import org.eclipse.codewind.intellij.core.Logger;
+import org.eclipse.codewind.intellij.core.constants.CoreConstants;
+import org.jetbrains.annotations.NotNull;
+
+import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
+
+public class AutoBuildTask extends Task.Backgroundable {
+
+    private final CodewindApplication application;
+    private final boolean enable;
+
+    public AutoBuildTask(CodewindApplication application, boolean enable) {
+        super(null, message("EnableDisableAutoBuildJob", application.name));
+        this.application = application;
+        this.enable = enable;
+    }
+
+    @Override
+    public void run(@NotNull ProgressIndicator indicator) {
+        try {
+            String actionKey = enable ? CoreConstants.VALUE_ACTION_ENABLEAUTOBUILD : CoreConstants.VALUE_ACTION_DISABLEAUTOBUILD;
+            application.connection.requestProjectBuild(application, actionKey);
+            application.setAutoBuild(enable);
+        } catch (Exception e) {
+            // Handled in #onThrowable()
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void onThrowable(@NotNull Throwable error) {
+        Throwable t = error;
+        while (t.getCause() != null)
+            t = t.getCause();
+        Logger.logWarning("An error occurred changing auto build setting for: " + application.name + ", with id: " + application.projectID, t);
+        Messages.showErrorDialog(message("ErrorOnEnableDisableAutoBuild", application.name, t.getLocalizedMessage()), "Codewind");
+    }
+
+    public static AutoBuildTask createEnabler(CodewindApplication application) {
+        return new AutoBuildTask(application, true);
+    }
+
+    public static AutoBuildTask createDisabler(CodewindApplication application) {
+        return new AutoBuildTask(application, false);
+    }
+}

--- a/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
+++ b/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
@@ -205,11 +205,11 @@ ShowOnContentChangeAction=Show on Content Change
 
 ActionNewConnection=&New Codewind Connection
 
-ActionOpenAppMonitor=Open Application &Monitor
+ActionOpenAppMonitor=Application &Monitor
 
-ActionOpenPerformanceMonitor=Open &Performance Dashboard
+ActionOpenPerformanceMonitor=&Performance Dashboard
 
-ActionOpenTektonDashboard=Open &Tekton Dashboard
+ActionOpenTektonDashboard=&Tekton Dashboard
 
 ValidateLabel=Validate
 AttachDebuggerLabel=A&ttach Debugger


### PR DESCRIPTION
See https://github.com/eclipse/codewind/issues/1974

Also fixed the order and labels of popup menu items to match Eclipse

Signed-off-by: John Pitman <jspitman@ca.ibm.com>