### PR TITLE
Clean up project creation

### DIFF
--- a/dev/.idea/runConfigurations/dev__latest___runIde_.xml
+++ b/dev/.idea/runConfigurations/dev__latest___runIde_.xml
@@ -4,6 +4,7 @@
       <option name="env">
         <map>
           <entry key="CW_TAG" value="latest" />
+          <entry key="filewatcher_log_level" value="ERROR" />
         </map>
       </option>
       <option name="executionName" />

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/CodewindApplication.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/CodewindApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.eclipse.codewind.intellij.core.constants.IntelliJConstants.IDEA_FOLDER;
+import static org.eclipse.codewind.intellij.core.constants.IntelliJConstants.IPR_FOLDER;
 
 /**
  * Represents a Codewind Application / Project
@@ -550,10 +553,10 @@ public class CodewindApplication {
 	public Path ideaProjectPath() {
 		// The IntelliJ project path is either the path to the (old) .ipr file,
 		// or the path to the parent folder of the .idea folder.
-		Path path = fullLocalPath.resolve(".idea");
+		Path path = fullLocalPath.resolve(IDEA_FOLDER);
 		if (Files.exists(path))
 			return fullLocalPath;
-		path = fullLocalPath.resolve(".ipr");
+		path = fullLocalPath.resolve(IPR_FOLDER);
 		if (Files.exists(path))
 			return path;
 		return null;

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/Logger.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/Logger.java
@@ -66,4 +66,11 @@ public class Logger {
     public static void log(Throwable t) {
         getLogger().info(t);
     }
+
+    public static Throwable unwrap(Throwable error) {
+        Throwable t = error;
+        while (t.getCause() != null)
+            t = t.getCause();
+        return t;
+    }
 }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/Logger.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/Logger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/constants/IntelliJConstants.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/constants/IntelliJConstants.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.intellij.core.constants;
+
+public class IntelliJConstants {
+    private IntelliJConstants() {
+    }
+
+    public static final String IDEA_FOLDER = ".idea";
+    public static final String IPR_FOLDER = ".ipr";
+}

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
@@ -67,7 +67,7 @@ public class CodewindModuleBuilder extends JavaModuleBuilder implements ModuleBu
     @Override
     public ModuleWizardStep getCustomOptionsStep(WizardContext context, Disposable parentDisposable) {
         // The custom options step's #onWizardFinished() method doesn't get called, so we can't use
-        // this step to do any validation when the user click's 'finish'.  Since we only have one real
+        // this step to do any validation when the user clicks 'finish'.  Since we only have one real
         // step to do the validation, that step has to be created in #createWizardSteps.
         // We still need to provide a custom option step so the user can select the JDK for the project.
         return new ModuleWizardStep() {

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
@@ -14,6 +14,7 @@ package org.eclipse.codewind.intellij.ui.module;
 import com.intellij.ide.util.projectWizard.*;
 import com.intellij.ide.wizard.CommitStepException;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.ModifiableModuleModel;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleWithNameAlreadyExists;
@@ -166,7 +167,13 @@ public class CodewindModuleBuilder extends JavaModuleBuilder implements ModuleBu
                     CoreUtil.openDialog(CoreUtil.DialogType.ERROR, message("CodewindLabel"), message("StartBuildError", name, thrown.getLocalizedMessage()));
                 }
 
-                // Reload the project so the maven importer will run
+                // Reload the project so the maven importer will run.  However, if the project is reloaded too
+                // soon the project sdk might not have been configured yet.
+                try {
+                    Thread.sleep(1000L);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
                 ProjectManager.getInstance().reloadProject(ideaProject);
             }
         };

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/InstallCodewindStep.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/InstallCodewindStep.java
@@ -69,6 +69,7 @@ public class InstallCodewindStep extends ModuleWizardStep {
     private void onInstall() {
         isInstalled = true;
         button.setEnabled(false);
-        label.setText(message("CodewindInstalledStarted"));
+        String txt = "<html>" + message("CodewindInstalledStarted") + "</html>";
+        label.setText(txt);
     }
 }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/NewCodewindProjectStep.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/NewCodewindProjectStep.java
@@ -12,6 +12,7 @@
 package org.eclipse.codewind.intellij.ui.module;
 
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
+import com.intellij.ide.wizard.CommitStepException;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.ui.components.JBScrollPane;
@@ -79,6 +80,11 @@ public class NewCodewindProjectStep extends ModuleWizardStep {
     @Override
     public boolean validate() throws ConfigurationException {
         return table.getSelectedRow() >= 0;
+    }
+
+    @Override
+    public void onWizardFinished() throws CommitStepException {
+        builder.onWizardFinished();
     }
 
     private TemplateTableModel getTableModel() {

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/StartCodewindStep.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/StartCodewindStep.java
@@ -71,6 +71,7 @@ public class StartCodewindStep extends ModuleWizardStep {
     private void onStart() {
         isStarted = true;
         button.setEnabled(false);
-        label.setText(message("CodewindStarted"));
+        String txt = "<html>" + message("CodewindStarted") + "</html>";
+        label.setText(txt);
     }
 }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/OpenIdeaProjectTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/OpenIdeaProjectTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static org.eclipse.codewind.intellij.core.constants.IntelliJConstants.IDEA_FOLDER;
 import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
 
 public class OpenIdeaProjectTask extends Task.Backgroundable {
@@ -56,7 +57,7 @@ public class OpenIdeaProjectTask extends Task.Backgroundable {
             System.out.println("*** creating idea project for: application" + application.getName());
             // If we don't create the '.idea' folder, the openOrImport() call fails (but weirdly, only
             // the first time)
-            Files.createDirectory(application.fullLocalPath.resolve(".idea"));
+            Files.createDirectory(application.fullLocalPath.resolve(IDEA_FOLDER));
             String project = application.fullLocalPath.toString();
             CoreUtil.invokeLater(
                     () -> {

--- a/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
+++ b/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
@@ -369,3 +369,5 @@ CodewindStarted=Codewind has started. To continue, click Next.
 CodewindNotInstalled=Codewind images must be installed in order to create projects or modules.
 InstallCodewind=Install Codewind Images
 CodewindInstalledStarted=Codewind has been installed and has started. To continue, click Next.
+
+ProjectFolderNotEmpty=Folder {0} is not empty. Codewind projects can only be created in an empty folder.

--- a/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
+++ b/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
@@ -364,10 +364,10 @@ CodewindModuleDescription=Codewind modules are used to develop Java applications
 
 CodewindNotStarted=Codewind must be running in order to create projects or modules.
 StartCodewind=Start Codewind
-CodewindStarted=Codewind has started. To continue, click Next.
+CodewindStarted=Codewind has started. To continue, click <b>Next</b>.
 
 CodewindNotInstalled=Codewind images must be installed in order to create projects or modules.
 InstallCodewind=Install Codewind Images
-CodewindInstalledStarted=Codewind has been installed and has started. To continue, click Next.
+CodewindInstalledStarted=Codewind has been installed and has started. To continue, click <b>Next</b>.
 
 ProjectFolderNotEmpty=Folder {0} is not empty. Codewind projects can only be created in an empty folder.


### PR DESCRIPTION
- Run project creation in the background
- Validate input for project creation

Also, not actually related to project creation, set the file-watcher logging level to ERROR when running self-hosted in the IntelliJ IDE.  Not this is only for dev time, and does not affect the setting for the shipped plugin,