### PR TITLE
[2274] Disable 'Add Existing Project' action if Codewind isn't started

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/AddExistingProjectAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/AddExistingProjectAction.java
@@ -13,6 +13,7 @@ package org.eclipse.codewind.intellij.ui.actions;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.ui.treeStructure.Tree;
+import org.eclipse.codewind.intellij.core.Logger;
 import org.eclipse.codewind.intellij.core.connection.CodewindConnection;
 import org.eclipse.codewind.intellij.ui.wizard.AbstractBindProjectWizardStep;
 import org.eclipse.codewind.intellij.ui.wizard.AddExistingProjectWizard;
@@ -36,9 +37,19 @@ public class AddExistingProjectAction extends AnAction {
     }
 
     @Override
+    public void update(@NotNull AnActionEvent e) {
+        // Warning: Update code must execute fast
+        CodewindConnection connection = getSelection(e);
+        e.getPresentation().setEnabled(connection == null ? false : connection.isConnected());
+    }
+
+    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         CodewindConnection connection = getSelection(e);
-        List<AbstractBindProjectWizardStep> steps = new ArrayList<AbstractBindProjectWizardStep>();
+        if (connection == null) {
+            return;
+        }
+        List<AbstractBindProjectWizardStep> steps = new ArrayList<>();
         steps.add(new ProjectFolderStep(message("SelectProjectPageName"), e.getProject(), connection));
         steps.add(new ConfirmProjectTypeStep(message("ProjectValidationPageTitle"), e.getProject(), connection));
         steps.add(new ProjectTypeSelectionStep(message("SelectProjectPageTitle"), e.getProject(), connection));
@@ -53,6 +64,10 @@ public class AddExistingProjectAction extends AnAction {
         }
         Tree tree = (Tree) data;
         TreePath treePath = tree.getSelectionPath();
+        if (treePath == null) {
+            Logger.log("No selection path for AddExistingProjectAction: " + tree);
+            return null;
+        }
         Object node = treePath.getLastPathComponent();
         if (!(node instanceof CodewindConnection)) {
             return null;

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/OpenAppOverviewAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/OpenAppOverviewAction.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.ui.treeStructure.Tree;
 import org.eclipse.codewind.intellij.core.CodewindApplication;
+import org.eclipse.codewind.intellij.core.Logger;
 import org.eclipse.codewind.intellij.ui.tasks.OpenAppOverviewTask;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,7 +33,7 @@ public class OpenAppOverviewAction extends AnAction {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         CodewindApplication application = getSelection(e);
-        if (e != null) {
+        if (application != null) {
             // Pass project to task and on to overview
             OpenAppOverviewTask task = new OpenAppOverviewTask(application, e.getProject());
             ProgressManager.getInstance().run(task);
@@ -46,6 +47,10 @@ public class OpenAppOverviewAction extends AnAction {
         }
         Tree tree = (Tree) data;
         TreePath treePath = tree.getSelectionPath();
+        if (treePath == null) {
+            Logger.log("No selection path for OpenAppOverviewAction: " + tree);
+            return null;
+        }
         Object node = treePath.getLastPathComponent();
         if (!(node instanceof CodewindApplication)) {
             return null;


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2274

See screenshots there.  Note other actions have to be updated too.

Signed-off-by: Keith Chong <kchong@ca.ibm.com>