### PR TITLE
[2326] SVT:Browse folder dialog content is empty

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/form/AddExistingProjectForm.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/form/AddExistingProjectForm.java
@@ -62,7 +62,7 @@ public class AddExistingProjectForm {
                 FileChooserDescriptor singleFolderDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor();
                 singleFolderDescriptor.setTitle(message("SelectProjectPageFilesystemProject"));
                 singleFolderDescriptor.setHideIgnored(true);
-                singleFolderDescriptor.setShowFileSystemRoots(false);
+                singleFolderDescriptor.setShowFileSystemRoots(true);
                 @SystemIndependent String basePath = project.getBasePath();
                 VirtualFile file = null;
                 if (basePath != null) {


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2326

See screenshot with fix in the above issue.

Signed-off-by: Keith Chong <kchong@ca.ibm.com>