### PR TITLE
Fixing link to docs

### DIFF
--- a/dev/src/main/resources/META-INF/plugin.xml
+++ b/dev/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     <p><b>0.9.0</b></p>
 <p>
     Initial tech preview release.
-    To get started, see <a href="https://www.eclipse.org/codewind/mdt-intellij-getting-started.html">Getting Started</a>.
+    To get started, see <a href="https://www.eclipse.org/codewind/intellij-getting-started.html">Getting Started</a>.
     </p>
     ]]>
     </change-notes>


### PR DESCRIPTION
Removing "mdt" in the link because the file name changed.