### PR TITLE
[2466] Select first log after running "Show All" logs

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
@@ -52,6 +52,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
 
@@ -71,8 +72,9 @@ public class ShowAllLogFilesTask extends Task.Backgroundable {
             @Override
             public void run() {
                 initToolWindow();
-
-                for (ProjectLogInfo logInfo : application.getLogInfos()) {
+                List<ProjectLogInfo> logInfos = application.getLogInfos();
+                ProjectLogInfo firstAppLog = logInfos.size() > 0 ? logInfos.get(0) : null;
+                for (ProjectLogInfo logInfo : logInfos) {
                     Content content = getContentForProjectLogInfo(logInfo);
                     SocketConsole socketConsole = null;
                     if (content == null) {
@@ -89,6 +91,10 @@ public class ShowAllLogFilesTask extends Task.Backgroundable {
                 if (!logFilesToolWindow.isVisible() && logFilesToolWindow.isAvailable()) {
                     logFilesToolWindow.show(null);
                     logFilesToolWindow.activate(null, true, true);
+                }
+                if (firstAppLog != null) {
+                    Content firstContent = getContentForProjectLogInfo(firstAppLog);
+                    logFilesToolWindow.getContentManager().setSelectedContent(firstContent);
                 }
             }
         });


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [X ] Bug fix
- [ ] Enhancement

## What does this PR do ?

Select the first log in the logs view after the user selects the `Show All` logs action for a project in the Codewind view

## Which issue(s) does this PR fix ? 

https://github.com/eclipse/codewind/issues/2466

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
This PR is for the 0.10.0 release / branch only.
