### PR TITLE
Make plugin version match what will be in updatePlugins.xml

### DIFF
--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -11,7 +11,7 @@ file('src/main/resources/install-version.properties').withInputStream {
 }
 
 group 'org.eclipse.codewind.intellij'
-version versionProperties.getProperty('install-version') + '-' + BUILD_TIME
+version versionProperties.getProperty('install-version')
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
Signed-off-by: John Pitman <jspitman@ca.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Strips the timestamp from the plugin version, so that it matches what will be in the updatePlugins.xml

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
