### PR TITLE
[2560] Pre-select the project in the Codewind view

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/WindowToolFactory.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/WindowToolFactory.java
@@ -22,7 +22,7 @@ public class WindowToolFactory implements ToolWindowFactory {
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
         CodewindToolWindow codewindToolWindow = new CodewindToolWindow();
         ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
-        toolWindow.getContentManager().addContent(contentFactory.createContent(codewindToolWindow, "", false));
+        toolWindow.getContentManager().addContent(contentFactory.createContent(codewindToolWindow, CodewindToolWindow.DISPLAY_NAME, false));
         codewindToolWindow.init();
     }
 }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
@@ -13,8 +13,12 @@ package org.eclipse.codewind.intellij.ui.tree;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManager;
 import org.eclipse.codewind.intellij.core.CoreUtil;
 import org.eclipse.codewind.intellij.ui.CodewindToolWindow;
+
+import javax.swing.JComponent;
 
 import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
 
@@ -29,7 +33,14 @@ public class CodewindToolWindowHelper {
             public void run() {
                 ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(CodewindToolWindow.ID);
                 if (toolWindow != null && toolWindow.isAvailable()) {
-                    toolWindow.show(null);
+                    toolWindow.show(this);
+                    ContentManager contentManager = toolWindow.getContentManager();
+                    final Content content = contentManager.findContent(CodewindToolWindow.DISPLAY_NAME);
+                    JComponent component = content.getComponent();
+                    if (content != null && component instanceof CodewindToolWindow) {
+                        CodewindToolWindow codewindToolWindow = (CodewindToolWindow)component;
+                        codewindToolWindow.expandToProject(project);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [X ] Enhancement - Part of Debug Support Enhancement

## What does this PR do ?
Expand tree and pre-select the project in the Codewind view after the project is opened in a new window

## Which issue(s) does this PR fix ?
Fixes https://github.com/eclipse/codewind/issues/2560

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
The New Project Action is a separate issue and the behavior is different.  That fix should be done in a separate PR