### PR TITLE
[2560] Pre-select the project in the Codewind view

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
@@ -33,7 +33,7 @@ public class CodewindToolWindowHelper {
             public void run() {
                 ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(CodewindToolWindow.ID);
                 if (toolWindow != null && toolWindow.isAvailable()) {
-                    toolWindow.show(this);
+                    toolWindow.show(null); // Keep this null
                     ContentManager contentManager = toolWindow.getContentManager();
                     final Content content = contentManager.findContent(CodewindToolWindow.DISPLAY_NAME);
                     JComponent component = content.getComponent();


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [ X ] Bug fix
- [ ] Enhancement

## What does this PR do ?
The fix should just be to pass null to the show() method, as it was originally.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2560

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No