### PR TITLE
Select codewind module type in new project wizard

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/NewCodewindProjectAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/NewCodewindProjectAction.java
@@ -12,18 +12,61 @@
 package org.eclipse.codewind.intellij.ui.actions;
 
 import com.intellij.ide.actions.NewProjectAction;
+import com.intellij.ide.impl.NewProjectUtil;
+import com.intellij.ide.projectWizard.NewProjectWizard;
+import com.intellij.ide.projectWizard.ProjectTypeStep;
+import com.intellij.ide.util.newProjectWizard.TemplatesGroup;
+import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
+import com.intellij.ui.components.JBList;
 import com.intellij.ui.treeStructure.Tree;
 import org.eclipse.codewind.intellij.core.Logger;
 import org.eclipse.codewind.intellij.core.connection.CodewindConnection;
+import org.eclipse.codewind.intellij.ui.module.CodewindModuleType;
 import org.jetbrains.annotations.NotNull;
 
+import javax.swing.*;
 import javax.swing.tree.TreePath;
+import java.util.List;
 
 import static com.intellij.openapi.actionSystem.PlatformDataKeys.CONTEXT_COMPONENT;
 import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
 
 public class NewCodewindProjectAction extends NewProjectAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        NewProjectWizard wizard = new NewProjectWizard(null, ModulesProvider.EMPTY_MODULES_PROVIDER, null);
+        try {
+            selectCodewindTemplate(wizard);
+        } catch (Exception ex) {
+            Logger.logWarning(ex);
+        }
+        NewProjectUtil.createNewProject(wizard);
+    }
+
+    private void selectCodewindTemplate(NewProjectWizard wizard) {
+        List<ModuleWizardStep> steps = wizard.getSequence().getAllSteps();
+        for (ModuleWizardStep step: steps) {
+            if (step instanceof ProjectTypeStep) {
+                ProjectTypeStep projectTypeStep = (ProjectTypeStep) step;
+                if (projectTypeStep.getPreferredFocusedComponent() instanceof JBList) {
+                    @SuppressWarnings("unchecked")
+                    JBList<TemplatesGroup> list = ((JBList<TemplatesGroup>)projectTypeStep.getPreferredFocusedComponent());
+                    ListModel<TemplatesGroup> model = (ListModel<TemplatesGroup>) list.getModel();
+                    for (int i = 0; i < model.getSize(); i++) {
+                        TemplatesGroup group = model.getElementAt(i);
+                        if (CodewindModuleType.CODEWIND_MODULE.equals(group.getId())) {
+                            list.setSelectedIndex(i);
+                            return;
+                        }
+                    }
+                }
+                return;
+            }
+        }
+    }
 
     @Override
     public void update(@NotNull AnActionEvent e) {


### PR DESCRIPTION
Signed-off-by: John Pitman <jspitman@ca.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Ensures the Codewind project type is selected in the new project wizard when the wizard is launched from the Codewind view

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2468

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?

No

## Any special notes for your reviewer ?
