### PR TITLE
[2037] Open and select project tree after project creation; Cancel

### DIFF
--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -97,5 +97,5 @@ defaultTasks 'copyDependencies', 'compileJava'
 intellij {
     version '2019.3'
     updateSinceUntilBuild false
-    plugins = ['java']
+    plugins = ['java', 'maven']
 }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
@@ -86,6 +86,8 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
 
     private final AnAction newProjectAction;
 
+    private Project initialSelectedProject;
+
     public CodewindToolWindow() {
         tree = new Tree();
         tree.setCellRenderer(new CodewindTreeNodeCellRenderer());
@@ -150,6 +152,10 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
             // Potentially, the Codewind tree model could be moved to the below handler
             CoreUtil.setToolWindowUpdateHandler(updateHandler);
             getTreeModel().updateAll();
+            if (this.initialSelectedProject != null) {
+                expandToProject(initialSelectedProject);
+                initialSelectedProject = null;
+            }
         });
     }
 
@@ -182,6 +188,10 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
         } else {
             tree.expandPath(new TreePath(new Object[]{root, child}));
         }
+    }
+
+    public void setInitialSelectedProject(Project project) {
+        this.initialSelectedProject = project;
     }
 
     public void expandToProject(Project project) {

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/SetupCodewindProjectRunnable.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/SetupCodewindProjectRunnable.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.codewind.intellij.ui.module;
+
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import org.eclipse.codewind.intellij.core.CoreUtil;
+import org.eclipse.codewind.intellij.core.FileUtil;
+import org.eclipse.codewind.intellij.core.Logger;
+import org.eclipse.codewind.intellij.core.cli.ProjectUtil;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
+
+public class SetupCodewindProjectRunnable implements Runnable {
+
+    private String path;
+    private String name;
+    private String url;
+    private String language;
+    private String projectType;
+    private String conId;
+    private String javaHome;
+
+    public SetupCodewindProjectRunnable(
+            String path,
+            String name,
+            String url,
+            String language,
+            String projectType,
+            String conId,
+            String javaHome) {
+
+        this.path = path;
+        this.name = name;
+        this.url = url;
+        this.language = language;
+        this.projectType = projectType;
+        this.conId = conId;
+        this.javaHome = javaHome;
+    };
+
+    @Override
+    public void run() throws ProcessCanceledException{
+        ProgressIndicator progressIndicator = ProgressManager.getInstance().getProgressIndicator();
+        try {
+            progressIndicator.setIndeterminate(false);
+            progressIndicator.setText2(message("PleaseWaitForBuild"));
+            Path projectPath = Paths.get(path);
+            progressIndicator.checkCanceled();
+
+            Path tmpProjectPath = Files.createTempDirectory("codewind").resolve(projectPath.getFileName());
+            progressIndicator.checkCanceled();
+
+            progressIndicator.setText(message("SettingUpProject"));
+            ProjectUtil.createProject(name, tmpProjectPath.toString(), url, conId, javaHome, progressIndicator);
+            progressIndicator.checkCanceled();
+            FileUtil.copyDirectory(tmpProjectPath, projectPath);
+            progressIndicator.checkCanceled();
+
+            progressIndicator.setText("Binding project");
+            ProjectUtil.bindProject(name, path, language, projectType, conId, progressIndicator);
+            progressIndicator.checkCanceled();
+
+            FileUtil.deleteDirectory(tmpProjectPath.getParent().toString(), true);
+            progressIndicator.checkCanceled();
+
+            progressIndicator.stop();
+        } catch (Exception error) {
+            if (!(error instanceof ProcessCanceledException)) {
+                Throwable thrown = Logger.unwrap(error);
+                Logger.logWarning("An error occurred creating project " + name, thrown);
+                CoreUtil.openDialog(CoreUtil.DialogType.ERROR,  message("NewProjectPage_ProjectCreateErrorTitle"),  message("StartBuildError", name, thrown.getLocalizedMessage()));
+            }
+        }
+    }
+}

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
@@ -73,6 +73,10 @@ public class ShowAllLogFilesTask extends Task.Backgroundable {
             public void run() {
                 initToolWindow();
                 List<ProjectLogInfo> logInfos = application.getLogInfos();
+                if (logInfos.size() == 0) {
+                    CoreUtil.openDialog(false, message("NoLogFilesAvailableTitle"), message("NoLogFilesAvailableMessage", application.getName()));
+                    return;
+                }
                 ProjectLogInfo firstAppLog = logInfos.size() > 0 ? logInfos.get(0) : null;
                 for (ProjectLogInfo logInfo : logInfos) {
                     Content content = getContentForProjectLogInfo(logInfo);

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
@@ -27,6 +27,10 @@ public class CodewindToolWindowHelper {
     // ID for the Log Files Tool Window
     public final static String SHOW_LOG_FILES_TOOLWINDOW_ID = message("LogFilesToolWindow");  // Note this ID is actually the UI displayed string in the ToolWindow
 
+    /**
+     * Open and expand to project
+     * @param project
+     */
     public static void openWindow(Project project) {
         CoreUtil.invokeLater(new Runnable() {
             @Override
@@ -44,5 +48,38 @@ public class CodewindToolWindowHelper {
                 }
             }
         });
+    }
+
+    /**
+     * Open Codewind window
+     * @param project
+     */
+    public static void openCodewindWindow(Project project) {
+        CoreUtil.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(CodewindToolWindow.ID);
+                if (toolWindow != null && toolWindow.isAvailable()) {
+                    toolWindow.show(null); // Keep this null
+                }
+            }
+        });
+    }
+
+    /**
+     * Set the project to be selected prior to the window being shown or opened, which can be much later
+     * @param project
+     */
+    public static void setInitialProjectToSelect(Project project) {
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(CodewindToolWindow.ID);
+        if (toolWindow != null && toolWindow.isAvailable()) {
+            ContentManager contentManager = toolWindow.getContentManager();
+            final Content content = contentManager.findContent(CodewindToolWindow.DISPLAY_NAME);
+            JComponent component = content.getComponent();
+            if (content != null && component instanceof CodewindToolWindow) {
+                CodewindToolWindow codewindToolWindow = (CodewindToolWindow)component;
+                codewindToolWindow.setInitialSelectedProject(project);
+            }
+        }
     }
 }

--- a/dev/src/main/resources/META-INF/plugin.xml
+++ b/dev/src/main/resources/META-INF/plugin.xml
@@ -89,6 +89,7 @@
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.java</depends>
+    <depends>org.jetbrains.idea.maven</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Codewind" anchor="left" secondary="true" icon="/META-INF/pluginIcon13x13.svg"

--- a/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
+++ b/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
@@ -216,6 +216,8 @@ ShowLogFilesMenu=&Log Files
 ShowAllLogFilesAction=&Show All
 CloseAllLogFilesAction=&Close All
 LogFilesToolWindow=Log Files
+NoLogFilesAvailableMessage=The project {0} does not have any logs available at this time. Wait for the project to build and try again.
+NoLogFilesAvailableTitle=No Log Files Available
 ErrorOnShowLogFileDialogTitle=An error occurred while opening or closing the stream for the log file.
 ShowOnContentChangeAction=Show on Content Change
 
@@ -238,6 +240,10 @@ RefreshProjectJobLabel=Refreshing project: {0}
 	
 ImportProjectError=An error occurred while importing the {0} project.
 StartBuildError=An error occurred while starting a build for the {0} project: {1}.
+SettingUpProject=Setting up project and dependencies.
+PleaseWaitForBuild=Please wait while dependencies are downloaded.
+NewProjectSetupProcessCanceledMessage=The project setup process was canceled. The project was not created.
+NewProjectSetupProcessCanceledTitle=Project Setup Canceled
 
 DialogYesButton=Yes
 DialogNoButton=No
@@ -276,6 +282,7 @@ BrowserSelectionNoBrowserSelected=No web browser selected
 
 NewProjectAction_Label=Create &New Project...
 NewProjectWizard_ShellTitle=New Codewind project
+NewProjectWizard_ProgressTitle=Creating New Project
 NewProjectPage_ShellTitle=New Codewind project
 NewProjectPage_WizardDescription=Enter a project name and select a project template.
 NewProjectPage_WizardTitle=Create a Codewind project


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [X] Enhancement

## What does this PR do ?
Enhancement to open the Codewind View and pre-select the project
Bug fix to fix what happens when cancel is pressed from the dialog to prompt the user to open the new project in a new window

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2037
https://github.com/eclipse/codewind/issues/2476
and a small safe, independent change to inform the user that no logs are available (similar to the VS Code extension's behavior).  It's included here because string changes were added.

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
New plugin dependency on maven, which is in the community version
See other notes mentioned in comments in the code

For the show log file fix, a safe change was made to:
dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
and two string were added:
```
NoLogFilesAvailableMessage=The project {0} does not have any logs available at this time. Wait for the project to build, and try again.
NoLogFilesAvailableTitle=No Log Files Available
```
