### PR TITLE
[2269] Use notifications to indicate that content of a log has changed

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/CoreUtil.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/CoreUtil.java
@@ -11,10 +11,14 @@
 
 package org.eclipse.codewind.intellij.core;
 
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.ui.Messages;
 import org.eclipse.codewind.intellij.core.connection.CodewindConnection;
+import org.eclipse.codewind.intellij.ui.IconCache;
+import org.eclipse.codewind.intellij.ui.tree.CodewindToolWindowHelper;
 
 import javax.swing.*;
 import java.awt.*;
@@ -33,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static com.intellij.openapi.application.ModalityState.defaultModalityState;
+import static org.eclipse.codewind.intellij.core.messages.CodewindCoreBundle.message;
 
 /**
  * General utils that don't belong anywhere else
@@ -44,6 +49,7 @@ public class CoreUtil {
 
     private static IUpdateHandler updateHandler;
     private static IUpdateHandler toolWindowUpdateHandler;
+    private static NotificationGroup logUpdatesNotificationGroup;
 
 	public enum DialogType {
 		ERROR,
@@ -51,6 +57,15 @@ public class CoreUtil {
 		INFO;
 	};
 
+	public static void initLogUpdatesNotificationGroup() {
+	    if (logUpdatesNotificationGroup == null) {
+            logUpdatesNotificationGroup = new NotificationGroup(message("LogUpdates"), NotificationDisplayType.TOOL_WINDOW, false, CodewindToolWindowHelper.SHOW_LOG_FILES_TOOLWINDOW_ID, IconCache.getCachedIcon(IconCache.ICONS_THEMELESS_CODEWIND_SVG));
+        }
+    }
+
+    public static NotificationGroup getLogUpdatesNotification() {
+	    return logUpdatesNotificationGroup;
+    }
 
     /**
      * Open a dialog on top of the current active window. Can be called off the UI thread.

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/console/ILogChangeNotifier.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/console/ILogChangeNotifier.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.codewind.intellij.core.console;
+
+public interface ILogChangeNotifier {
+    void notifyChange(String displayName);
+}

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/console/SocketConsole.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/console/SocketConsole.java
@@ -24,17 +24,21 @@ public class SocketConsole {
     public final CodewindApplication app;
     public final ProjectLogInfo logInfo;
     private final CodewindSocket socket;
+    private String consoleName;
 
     private boolean isInitialized = false;
     private Content content;
     private ConsoleView consoleView;
+    private final ILogChangeNotifier notifier;
 
-    public SocketConsole(Content content, ConsoleView consoleView, String consoleName, ProjectLogInfo logInfo, CodewindApplication app) {
+    public SocketConsole(Content content, ConsoleView consoleView, String consoleName, ProjectLogInfo logInfo, CodewindApplication app, ILogChangeNotifier iLogChangeNotifier) {
         this.logInfo = logInfo;
         this.app = app;
         this.socket = app.connection.getSocket();
         this.content = content;
         this.consoleView = consoleView;
+        this.consoleName = consoleName;
+        this.notifier = iLogChangeNotifier;
     }
 
     public void initialize() throws Exception {
@@ -58,6 +62,11 @@ public class SocketConsole {
                 consoleView.clear();
             }
             isInitialized = true;
+        }
+        if (!consoleView.getComponent().isShowing()) {
+            synchronized(notifier) {
+                notifier.notifyChange(this.consoleName);
+            }
         }
         // Todo: investigate how else we can print with different content types
         consoleView.print(contents, ConsoleViewContentType.NORMAL_OUTPUT);

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/CodewindToolWindow.java
@@ -146,6 +146,7 @@ public class CodewindToolWindow extends JBPanel<CodewindToolWindow> {
 
     public void init() {
         updateHandler = UpdateHandler.getInstance();
+        CoreUtil.initLogUpdatesNotificationGroup();
         CoreUtil.runAsync(() -> {
             tree.setModel(getTreeModel());
             CoreUtil.setUpdateHandler(getTreeModel());

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
@@ -46,6 +46,7 @@ import org.eclipse.codewind.intellij.core.console.SocketConsole;
 import org.eclipse.codewind.intellij.ui.CodewindToolWindow;
 import org.eclipse.codewind.intellij.ui.IconCache;
 import org.eclipse.codewind.intellij.ui.constants.UIConstants;
+import org.eclipse.codewind.intellij.ui.toolwindow.LogsViewNotifier;
 import org.eclipse.codewind.intellij.ui.toolwindow.UpdateHandler;
 import org.eclipse.codewind.intellij.ui.tree.CodewindToolWindowHelper;
 import org.jetbrains.annotations.NotNull;
@@ -61,6 +62,7 @@ public class ShowAllLogFilesTask extends Task.Backgroundable {
     private final CodewindApplication application;
     private ToolWindow logFilesToolWindow;
     private ContentManager contentManager = null;
+    private LogsViewNotifier notifier;
 
     public ShowAllLogFilesTask(CodewindApplication application, Project project) {
         super(project, message("ShowAllLogFilesAction"));
@@ -113,6 +115,7 @@ public class ShowAllLogFilesTask extends Task.Backgroundable {
             logFilesToolWindow = toolWindowManager.registerToolWindow(CodewindToolWindowHelper.SHOW_LOG_FILES_TOOLWINDOW_ID, true, ToolWindowAnchor.BOTTOM);
             logFilesToolWindow.setContentUiType(ToolWindowContentUiType.COMBO, null);
             logFilesToolWindow.setIcon(IconCache.getCachedIcon(IconCache.ICONS_CODEWIND_13PX_SVG));
+            logFilesToolWindow.setStripeTitle(message("LogFilesToolWindow"));
         }
         contentManager = logFilesToolWindow.getContentManager();
         if (windowRequiresRegistration) {
@@ -164,8 +167,11 @@ public class ShowAllLogFilesTask extends Task.Backgroundable {
         content.setDescription(org.eclipse.codewind.intellij.core.messages.CodewindCoreBundle.message("LogFileConsoleName", application.name, logInfo.logName));
         contentManager.addContent(content);
         Disposer.register(getProject(), consoleView);
-        
-        SocketConsole socketConsole = new SocketConsole(content, consoleView, content.getDisplayName(), logInfo, application);
+
+        if (notifier == null) {
+            notifier = new LogsViewNotifier(getProject());
+        }
+        SocketConsole socketConsole = new SocketConsole(content, consoleView, content.getDisplayName(), logInfo, application, notifier);
         DefaultActionGroup toolbarGroup = new DefaultActionGroup();
 
         AnAction[] consoleActions = consoleView.createConsoleActions();

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/toolwindow/LogsViewNotifier.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/toolwindow/LogsViewNotifier.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.codewind.intellij.ui.toolwindow;
+
+import com.intellij.notification.Notification;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManager;
+import org.eclipse.codewind.intellij.core.CoreUtil;
+import org.eclipse.codewind.intellij.core.console.ILogChangeNotifier;
+import org.eclipse.codewind.intellij.ui.IconCache;
+import org.eclipse.codewind.intellij.ui.tree.CodewindToolWindowHelper;
+
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.html.HTML;
+import java.util.Enumeration;
+
+import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message;
+
+public class LogsViewNotifier implements ILogChangeNotifier {
+
+    private static final String HTML_HREF = "href"; // Do not externalize
+
+    private Project project;
+    private String message = "";
+
+    public LogsViewNotifier(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public synchronized void notifyChange(String displayName) {
+        final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+        Balloon logFilesWindowBalloon = toolWindowManager.getToolWindowBalloon(CodewindToolWindowHelper.SHOW_LOG_FILES_TOOLWINDOW_ID);
+        String htmlContent = message("LogFilesNotification"); // "Changed Logs:\n";
+        // Do not externalize these strings.  These are HTML links.
+        if (logFilesWindowBalloon != null) {
+            String originalMessage = message;
+            if (message.contains(displayName)) {
+                message = message.replace("<a href='" + displayName + "'>" + displayName + "</a>\n", "");
+            }
+            message = "<a href='" + displayName + "'>" + displayName + "</a>\n" + message;
+            if (originalMessage.equals(message)) {
+                return; // No need to notify again since the log file is already in the notification
+            }
+        } else {
+            message = "<a href='" + displayName + "'>" + displayName + "</a>\n";
+        }
+        htmlContent = htmlContent.concat(message);
+        Notification notification = CoreUtil.getLogUpdatesNotification().createNotification();
+        notification.setContent(htmlContent);
+        notification.setIcon(IconCache.getCachedIcon(IconCache.ICONS_THEMELESS_CODEWIND_SVG));
+        notification.setListener((aNotification, hyperlinkEvent) -> {
+            HyperlinkEvent.EventType eventType = hyperlinkEvent.getEventType();
+            if (eventType == HyperlinkEvent.EventType.ACTIVATED) {
+                Element sourceElement = hyperlinkEvent.getSourceElement();
+                AttributeSet attributes = sourceElement.getAttributes();
+                Enumeration<?> attributeNames = attributes.getAttributeNames();
+                ContentManager contentManager = toolWindowManager.getToolWindow(CodewindToolWindowHelper.SHOW_LOG_FILES_TOOLWINDOW_ID).getContentManager();
+                ToolWindow logWindow = toolWindowManager.getToolWindow(CodewindToolWindowHelper.SHOW_LOG_FILES_TOOLWINDOW_ID);
+                while (attributeNames.hasMoreElements()) {
+                    Object o = attributeNames.nextElement();
+                    if (o instanceof HTML.Attribute) {
+                        HTML.Attribute attr = (HTML.Attribute) o;
+                        String attrString = attr.toString();
+                        if (HTML_HREF.equals(attrString)) {
+                            Object attribute = attributes.getAttribute(attr);
+                            String logFile = attribute.toString();
+                            Content content = contentManager.findContent(logFile);
+                            if (logWindow != null && !logWindow.isVisible() || !logWindow.isActive()) {
+                                logWindow.show(null);
+                            }
+                            if (content != null) {
+                                contentManager.setSelectedContent(content);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        notification.notify(project);
+    }
+}

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindToolWindowHelper.java
@@ -25,7 +25,7 @@ import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message
 public class CodewindToolWindowHelper {
 
     // ID for the Log Files Tool Window
-    public final static String SHOW_LOG_FILES_TOOLWINDOW_ID = message("LogFilesToolWindow");  // Note this ID is actually the UI displayed string in the ToolWindow
+    public final static String SHOW_LOG_FILES_TOOLWINDOW_ID = "org.eclipse.codewind.intellij.ui.logFilesToolWindow";
 
     /**
      * Open and expand to project

--- a/dev/src/main/resources/messages/core/CodewindCoreBundle.properties
+++ b/dev/src/main/resources/messages/core/CodewindCoreBundle.properties
@@ -87,3 +87,5 @@ ProjectErrorTitle=A problem occurred with the {0} project
 #IntelliJ
 #File Types
 CwSettingsFileTypeDescription=.cw-settings (Codewind Settings)
+#Log
+LogUpdates=Codewind Log Updates

--- a/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
+++ b/dev/src/main/resources/messages/ui/CodewindUIBundle.properties
@@ -218,6 +218,7 @@ CloseAllLogFilesAction=&Close All
 LogFilesToolWindow=Log Files
 NoLogFilesAvailableMessage=The project {0} does not have any logs available at this time. Wait for the project to build and try again.
 NoLogFilesAvailableTitle=No Log Files Available
+LogFilesNotification=Changed Logs:\n
 ErrorOnShowLogFileDialogTitle=An error occurred while opening or closing the stream for the log file.
 ShowOnContentChangeAction=Show on Content Change
 


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [X ] Enhancement

## What does this PR do ?
Add notifications 'balloons' whenever a log file has been updated but the console is not in view. This can be turned off in the preferences page.

## Which issue(s) does this PR fix ?

Fixes https://github.com/eclipse/codewind/issues/2269

## Does this PR require a documentation change ?
Yes - if we want to document how to turn off the notifications. See screencap in the issue.  We're contributing one entry into that table.

## Any special notes for your reviewer ?
No