### PR TITLE
[2722] Installer error message should not be displayed in Codewind view

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindTreeNodeCellRenderer.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tree/CodewindTreeNodeCellRenderer.java
@@ -203,9 +203,10 @@ public class CodewindTreeNodeCellRenderer extends DefaultTreeCellRenderer {
                         message("CodewindWrongVersionMsg", InstallUtil.getVersion());
             } else if (status.isError()) {
                 String msg = manager.getInstallerErrorMsg();
-                if (msg == null)
-                    msg = message("CodewindErrorMsg");
-                return text + " [" + message("CodewindErrorQualifier") + "] (" +msg + ")";
+                if (msg != null) {
+                    Logger.log(msg); // Log this as INFO so it will be in the IntelliJ log by default (trace does not have to be enabled)
+                }
+                return text + " [" + message("CodewindErrorQualifier") + "] (" + message("CodewindErrorMsg") + ")";
             } else if (status.isUnknown()) {
                 return text + " [ " + message("RefreshingCodewindStatus") + " ]";
             } else {


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Changes the content of the Codewind Connection node when an installer error occurs

## Which issue(s) does this PR fix ?
Fixes https://github.com/eclipse/codewind/issues/2722

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No