### PR TITLE
[2881] Enable remote connections in new project menu action

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/NewCodewindProjectAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/NewCodewindProjectAction.java
@@ -17,12 +17,14 @@ import com.intellij.ide.projectWizard.NewProjectWizard;
 import com.intellij.ide.projectWizard.ProjectTypeStep;
 import com.intellij.ide.util.newProjectWizard.TemplatesGroup;
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
+import com.intellij.ide.util.projectWizard.ProjectBuilder;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.ui.components.JBList;
 import com.intellij.ui.treeStructure.Tree;
 import org.eclipse.codewind.intellij.core.Logger;
 import org.eclipse.codewind.intellij.core.connection.CodewindConnection;
+import org.eclipse.codewind.intellij.ui.module.CodewindModuleBuilder;
 import org.eclipse.codewind.intellij.ui.module.CodewindModuleType;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,8 +39,14 @@ public class NewCodewindProjectAction extends NewProjectAction {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
+        CodewindConnection connection = getSelection(e);
         NewProjectWizard wizard = new NewProjectWizard(null, ModulesProvider.EMPTY_MODULES_PROVIDER, null);
         try {
+            ProjectBuilder projectBuilder = wizard.getProjectBuilder();
+            if (projectBuilder instanceof CodewindModuleBuilder) {
+                CodewindModuleBuilder moduleBuilder = (CodewindModuleBuilder)projectBuilder;
+                moduleBuilder.setConnection(connection);
+            }
             selectCodewindTemplate(wizard);
         } catch (Exception ex) {
             Logger.logWarning(ex);

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/NewCodewindProjectStep.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/NewCodewindProjectStep.java
@@ -19,6 +19,7 @@ import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
 import org.eclipse.codewind.intellij.core.Logger;
 import org.eclipse.codewind.intellij.core.cli.TemplateUtil;
+import org.eclipse.codewind.intellij.core.connection.CodewindConnection;
 import org.eclipse.codewind.intellij.core.connection.LocalConnection;
 import org.eclipse.codewind.intellij.core.connection.ProjectTemplateInfo;
 import org.eclipse.codewind.intellij.core.constants.ProjectLanguage;
@@ -33,6 +34,7 @@ import static org.eclipse.codewind.intellij.ui.messages.CodewindUIBundle.message
 public class NewCodewindProjectStep extends ModuleWizardStep {
 
     private final CodewindModuleBuilder builder;
+    private CodewindConnection connection;
 
     private final JPanel panel;
     private final JTable table;
@@ -53,6 +55,10 @@ public class NewCodewindProjectStep extends ModuleWizardStep {
         panel.add(scroll);
     }
 
+    public void setConnection(CodewindConnection connection) {
+        this.connection = connection;
+    }
+
     @Override
     public JComponent getComponent() {
         return panel;
@@ -67,7 +73,11 @@ public class NewCodewindProjectStep extends ModuleWizardStep {
     public void updateStep() {
         try {
             String javaID = ProjectLanguage.LANGUAGE_JAVA.getId();
-            List<ProjectTemplateInfo> templates = TemplateUtil.listTemplates(true, LocalConnection.DEFAULT_ID, new EmptyProgressIndicator())
+            String conId = LocalConnection.DEFAULT_ID;
+            if (this.connection != null) {
+                conId = connection.getConid();
+            }
+            List<ProjectTemplateInfo> templates = TemplateUtil.listTemplates(true, conId, new EmptyProgressIndicator())
                     .stream()
                     .filter(info -> info.getLanguage().equals(javaID))
                     .collect(Collectors.toList());


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
Enables remote connection support in the New Codewind Project context menu action and the Module builder and related steps.

## Which issue(s) does this PR fix ?
Fixes https://github.com/eclipse/codewind/issues/2881

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
See issue https://github.com/eclipse/codewind/issues/2881 for the scope.  There is a related enhancement to add a connections page to the wizard.

This PR should not impact the local connection behaviour.  The change simply allows for remote connections in addition to local connections.  The rest of the remote connection support will depend on this piece.
