### PR TITLE
Fix open shell in container, fix most deprecation warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ pipeline {
                             echo '<!-- Build date: '$TIMESTAMP '-->' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML
                             echo '<plugins>' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML
                             echo '    <plugin id="org.eclipse.codewind.intellij" url="'$DOWNLOAD_AREA_URL/$GIT_BRANCH/$LATEST_DIR/$OUTPUT_NAME.zip'" version="'$TIMESTAMP'">' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML
-                            echo '        <idea-version since-build="193.5233.102" until-build="999.*"/>' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML
+                            echo '        <idea-version since-build="201.7223.91" until-build="999.*"/>' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML
                             echo '        <name>Codewind</name>' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML
                             echo '        <description>Adds support for developing cloud-native, containerized web applications.</description>' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML
                             echo '    </plugin>' >> $OUTPUT_DIR/$UPDATE_PLUGINS_XML

--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -95,7 +95,7 @@ defaultTasks 'copyDependencies', 'compileJava'
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.3'
+    version '2020.1.1'
     updateSinceUntilBuild false
     plugins = ['java', 'maven', 'terminal']
 }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/filetypes/CwSettingsFileTypeDetector.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/filetypes/CwSettingsFileTypeDetector.java
@@ -50,12 +50,6 @@ public class CwSettingsFileTypeDetector implements FileTypeRegistry.FileTypeDete
         return null;
     }
 
-    @Nullable
-    @Override
-    public Collection<? extends FileType> getDetectedFileTypes() {
-        return Collections.singletonList(CwSettingsFileType.INSTANCE);
-    }
-
     @Override
     /*
      * Cached - if detect method changes, update version

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/launch/CoreUiUtil.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/launch/CoreUiUtil.java
@@ -56,7 +56,8 @@ public class CoreUiUtil {
         }
         // Set the run config on the application to delete later when the project is switch to run mode (Necessary cast)
         ((CodewindIntellijApplication)application).setRunnerAndConfigurationSettings(configurationByTypeAndName);
-        runManager.addConfiguration(configurationByTypeAndName, false);
+        configurationByTypeAndName.storeInLocalWorkspace();
+        runManager.addConfiguration(configurationByTypeAndName);
         // Set the current configuration, for the toolbar
         runManager.setSelectedConfiguration(configurationByTypeAndName);
         runManager.setTemporaryConfiguration(configurationByTypeAndName);

--- a/dev/src/main/java/org/eclipse/codewind/intellij/core/messages/CodewindCoreBundle.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/core/messages/CodewindCoreBundle.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.codewind.intellij.core.messages;
 
-import com.intellij.CommonBundle;
+import com.intellij.AbstractBundle;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.PropertyKey;
@@ -27,7 +27,7 @@ public class CodewindCoreBundle {
     private static Reference<ResourceBundle> bundleRef;
 
     public static String message(@NotNull @PropertyKey(resourceBundle = BUNDLE_NAME) String key, @NotNull Object... params) {
-        return CommonBundle.message(getBundle(), key, params);
+        return AbstractBundle.message(getBundle(), key, params);
     }
 
     private static ResourceBundle getBundle() {

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/OpenContainerShellAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/OpenContainerShellAction.java
@@ -66,7 +66,7 @@ public class OpenContainerShellAction extends AbstractProjectDependentAction {
                 String cmd = processPath + " " + processArgs;
                 TerminalView terminalView = TerminalView.getInstance(myProject);
                 try {
-                    ShellTerminalWidget w = terminalView.createLocalShellWidget(null);
+                    ShellTerminalWidget w = terminalView.createLocalShellWidget(null, app.getName());
                     w.executeCommand(cmd);
                     w.requestFocusInWindow();
                 } catch (IOException e) {

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/RemoveProjectAction.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/actions/RemoveProjectAction.java
@@ -71,7 +71,7 @@ public class RemoveProjectAction extends AnAction {
         } else {
             message = message("UnbindActionMultipleMessage", applications.size());
         }
-        int response = Messages.showConfirmationDialog(tree, message, title, Messages.OK_BUTTON, Messages.CANCEL_BUTTON);
+        int response = Messages.showConfirmationDialog(tree, message, title, Messages.getOkButton(), Messages.getCancelButton());
         if (response == Messages.OK) {
             ProgressManager.getInstance().run(new RemoveProjectTask(applications));
         }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/messages/CodewindUIBundle.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/messages/CodewindUIBundle.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.codewind.intellij.ui.messages;
 
-import com.intellij.CommonBundle;
+import com.intellij.AbstractBundle;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.PropertyKey;
@@ -27,7 +27,7 @@ public class CodewindUIBundle {
     private static Reference<ResourceBundle> bundleRef;
 
     public static String message(@NotNull @PropertyKey(resourceBundle = BUNDLE_NAME) String key, @NotNull Object... params) {
-        return CommonBundle.message(getBundle(), key, params);
+        return AbstractBundle.message(getBundle(), key, params);
     }
 
     private static ResourceBundle getBundle() {

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
@@ -198,7 +198,7 @@ public class CodewindModuleBuilder extends JavaModuleBuilder implements ModuleBu
             MavenProjectsManager manager = MavenProjectsManager.getInstance(project);
             if (manager != null && virtualFile != null) {
                 manager.addManagedFilesOrUnignore(Collections.singletonList(virtualFile));
-                manager.scheduleImportAndResolve(false);
+                manager.scheduleImportAndResolve();
             }
         }
     }

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/OpenAppOverviewTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/OpenAppOverviewTask.java
@@ -12,11 +12,7 @@ package org.eclipse.codewind.intellij.ui.tasks;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.browsers.BrowserLauncher;
-import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.actionSystem.ActionPlaces;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
@@ -25,11 +21,7 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowAnchor;
 import com.intellij.openapi.wm.ToolWindowContentUiType;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.ui.content.Content;
-import com.intellij.ui.content.ContentFactory;
-import com.intellij.ui.content.ContentManager;
-import com.intellij.ui.content.ContentManagerAdapter;
-import com.intellij.ui.content.ContentManagerEvent;
+import com.intellij.ui.content.*;
 import com.intellij.ui.content.tabs.TabbedContentAction;
 import org.eclipse.codewind.intellij.core.CodewindApplication;
 import org.eclipse.codewind.intellij.core.CoreUtil;
@@ -71,7 +63,7 @@ public class OpenAppOverviewTask extends Task.Backgroundable {
                     overviewToolWindow.setContentUiType(ToolWindowContentUiType.TABBED, null);
                     overviewToolWindow.setIcon(IconCache.getCachedIcon(IconCache.ICONS_CODEWIND_13PX_SVG));
                     contentManager = overviewToolWindow.getContentManager();
-                    contentManager.addContentManagerListener(new ContentManagerAdapter() {
+                    contentManager.addContentManagerListener(new ContentManagerListener() {
                         // Manually closing the overview page.  Remove the UpdateHandler listener
                         public void contentRemoved(@NotNull ContentManagerEvent event) {
                             ContentManagerEvent.ContentOperation operation = event.getOperation();

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/tasks/ShowAllLogFilesTask.java
@@ -16,11 +16,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.ide.actions.NextOccurenceToolbarAction;
 import com.intellij.ide.actions.PreviousOccurenceToolbarAction;
 import com.intellij.ide.browsers.BrowserLauncher;
-import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.actionSystem.ActionPlaces;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
@@ -31,11 +27,7 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowAnchor;
 import com.intellij.openapi.wm.ToolWindowContentUiType;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.ui.content.Content;
-import com.intellij.ui.content.ContentFactory;
-import com.intellij.ui.content.ContentManager;
-import com.intellij.ui.content.ContentManagerAdapter;
-import com.intellij.ui.content.ContentManagerEvent;
+import com.intellij.ui.content.*;
 import com.intellij.ui.content.tabs.TabbedContentAction;
 import org.eclipse.codewind.intellij.core.CodewindApplication;
 import org.eclipse.codewind.intellij.core.CoreUtil;
@@ -119,7 +111,7 @@ public class ShowAllLogFilesTask extends Task.Backgroundable {
         }
         contentManager = logFilesToolWindow.getContentManager();
         if (windowRequiresRegistration) {
-            contentManager.addContentManagerListener(new ContentManagerAdapter() {
+            contentManager.addContentManagerListener(new ContentManagerListener() {
                 public void contentRemoved(@NotNull ContentManagerEvent event) {
                     ContentManagerEvent.ContentOperation operation = event.getOperation();
                     if (operation.equals(ContentManagerEvent.ContentOperation.remove)) {

--- a/dev/src/main/resources/META-INF/plugin.xml
+++ b/dev/src/main/resources/META-INF/plugin.xml
@@ -95,7 +95,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="193.5233.102"/>
+    <idea-version since-build="201.7223.91"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->


### PR DESCRIPTION
This requires moving up to the 2020.1.1 version of IntelliJ

Signed-off-by: John Pitman <jspitman@ca.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Fixes the problem with opening the container shell with IntelliJ 2020.1.1

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2952

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?

Yes, we need to update the minimum supported level of IntelliJ

## Any special notes for your reviewer ?
