### PR TITLE
[2996] Create extensible codewind-specific dialog wrapper

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/form/AbstractCodewindDialogWrapper.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/form/AbstractCodewindDialogWrapper.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.codewind.intellij.ui.form;
+
+import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import org.eclipse.codewind.intellij.core.Logger;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Extensible dialog provides extenders a Help button (that does not launch the Jetbrains help), a Cancel and an OK button.
+ * Extenders should implement createCenterPanel() to provide custom widget content
+ */
+public abstract class AbstractCodewindDialogWrapper extends DialogWrapper {
+
+    private String helpUrl;
+
+    public AbstractCodewindDialogWrapper(Project project, String title, String helpUrl) {
+        super(project,true); // Can use current dialog window as parent for other child dialogs
+        init();
+        setTitle(title);
+        this.helpUrl = helpUrl;
+    }
+
+    @Nullable
+    @Override
+    protected String getHelpId() {
+        return ""; // Must not be null otherwise the help button question icon will not appear
+    }
+
+    @Override
+    protected void doHelpAction() {
+        try {
+            BrowserLauncher.getInstance().browse(new URI(helpUrl));
+        } catch (URISyntaxException ex) {
+            Logger.logDebug("Exception when lanching browser", ex);
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X ] Enhancement

## What does this PR do ?
This PR adds an extensible dialog wrapper class that any Codewind for IntelliJ feature can use whenever a new dialog (not wizard) is needed to be created.  This dialog provides  OK and Cancel buttons as well as a hooked in help button (a question mark) that when clicked, will open up the browser on the URL of your choice (eg. Codewind help page).   If your dialog class instead extends DialogWrapper, the browser will open up to the IntelliJ JetBrains help.  It appears to be hardcoded.

The extender/developer simply has to implement the method 
  protected abstract JComponent createCenterPanel();
to contribute the customized widget content.

## Which issue(s) does this PR fix ?
Fixes https://github.com/eclipse/codewind/issues/2996

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No