### PR TITLE
[985][2647] Manage Secure and Non-Secure Template Sources - Add'l fix

### DIFF
--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/CodewindModuleBuilder.java
@@ -191,7 +191,10 @@ public class CodewindModuleBuilder extends JavaModuleBuilder implements ModuleBu
         // True if operation completed successfully, or false if cancelled.
         try {
             // Handle error conditions. The template source repo might not be found or available. IOException (404) possible
-            ProgressManager.getInstance().runProcessWithProgressSynchronously(setupProjectRunnable, message("NewProjectWizard_ProgressTitle"), true, ideaProject);
+            Object rc = ProgressManager.getInstance().runProcessWithProgressSynchronously(setupProjectRunnable, message("NewProjectWizard_ProgressTitle"), true, ideaProject);
+            if (rc instanceof Boolean) {
+                isSuccessful = ((Boolean) rc).booleanValue();
+            }
         } catch (Exception e) {
             if (!(e instanceof ProcessCanceledException)) { // If the user cancelled it, don't log it
                 Throwable thrown = Logger.unwrap(e);

--- a/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/SetupCodewindProjectRunnable.java
+++ b/dev/src/main/java/org/eclipse/codewind/intellij/ui/module/SetupCodewindProjectRunnable.java
@@ -76,8 +76,7 @@ public class SetupCodewindProjectRunnable implements ThrowableComputable {
         progressIndicator.checkCanceled();
 
         progressIndicator.stop();
-        // Since we don't have anything meaningful to return, just return true for success since no exceptions were
-        // thrown at this point
-        return true;
+        // return true for success since no exceptions were thrown at this point
+        return Boolean.TRUE;
     }
 }


### PR DESCRIPTION
Signed-off-by: Keith Chong <kchong@ca.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
Additional change to fix an issue discovered after testing was 'unblocked'.  Needed when creating the project.  This is a must fix.   This is part of enhancement https://github.com/eclipse/codewind/issues/985

and the original PR https://github.com/eclipse/codewind-intellij/pull/137

## Does this PR require a documentation change ?
Not specifically this change. 985, yes.

## Any special notes for your reviewer ?
None.